### PR TITLE
Create winget-publish.yml

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,31 @@
+name: WinGet submission on release
+# based off of https://github.com/nushell/nushell/blob/main/.github/workflows/winget-submission.yml
+# inspired by https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml
+# Modified by @MerrickZ https://github.com/anpho
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit v2ray package to Windows Package Manager Community Repository
+        run: |
+
+          $wingetPackage = "2dust.v2rayN"
+          $gitToken = "${{ secrets.PT_WINGET }}"
+
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/2dust/v2rayN/releases" 
+
+          $targetRelease = $github | Where-Object -Property prerelease -match 'False' | Select -First 1
+          $installerUrl  = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'v2rayN-With-Core\.zip*' | Select -ExpandProperty browser_download_url
+
+          $ver = $targetRelease.tag_name
+
+          # getting latest wingetcreate file
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $wingetPackage -s -v $ver -u "$installerUrl|x64" -t $gitToken


### PR DESCRIPTION
Hi there,
This PR will enable automatically publishing to winget registry after release.

Note.

**A classic token with public_repo privillege is needed in order to commit to winget, secret's name should be PT_WINGET as refered in the yml file.**

Should be able to use ``` winget install 2dust.v2rayn``` on PC to download and add v2rayn.exe to PATH.